### PR TITLE
Feature/flyway migrations

### DIFF
--- a/Backend/src/main/resources/application.yaml
+++ b/Backend/src/main/resources/application.yaml
@@ -1,3 +1,16 @@
 spring:
   application:
     name: delivery-api
+
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/delivery_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+
+  jpa:
+    open-in-view: false
+    show-sql: true
+    properties:
+      hibernate:
+        ddl-auto: validate
+        format_sql: true

--- a/Backend/src/main/resources/db/migration/V1__init_schema.sql
+++ b/Backend/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,81 @@
+CREATE TABLE IF NOT EXISTS stores (
+                                      id UUID PRIMARY KEY,
+                                      name VARCHAR(255) NOT NULL,
+                                      created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+                                      id UUID PRIMARY KEY,
+                                      store_id UUID NOT NULL,
+                                      total_price DECIMAL(10,2) NOT NULL CHECK(total_price >= 0),
+                                      last_status VARCHAR(50) NOT NULL CHECK(last_status IN ('RECEIVED', 'CONFIRMED', 'DISPATCHED', 'DELIVERED', 'CANCELED')),
+                                      customer_name VARCHAR(255) NOT NULL,
+                                      customer_phone VARCHAR(50),
+                                      created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                                      updated_at TIMESTAMP WITH TIME ZONE,
+                                      FOREIGN KEY (store_id) REFERENCES stores(id)
+);
+
+CREATE INDEX idx_orders_store ON orders (store_id);
+CREATE INDEX idx_orders_created_at ON orders (created_at);
+
+CREATE TABLE IF NOT EXISTS delivery_addresses (
+                                                  order_id UUID PRIMARY KEY,
+                                                  coordinate_id BIGINT,
+                                                  latitude DECIMAL(10,8),
+                                                  longitude DECIMAL(11,8),
+                                                  street_name VARCHAR(255) NOT NULL,
+                                                  street_number VARCHAR(50),
+                                                  neighborhood VARCHAR(100),
+                                                  city VARCHAR(100) NOT NULL,
+                                                  state VARCHAR(50) NOT NULL,
+                                                  postal_code VARCHAR(20) NOT NULL,
+                                                  country CHAR(2) DEFAULT 'BR',
+                                                  reference TEXT,
+                                                  FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+                                           id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                                           order_id UUID NOT NULL,
+                                           external_code INTEGER,
+                                           name VARCHAR(255) NOT NULL,
+                                           quantity INTEGER NOT NULL CHECK(quantity > 0),
+                                           unit_price DECIMAL(10,2) NOT NULL CHECK(unit_price >= 0),
+                                           total_price DECIMAL(10,2) NOT NULL CHECK(total_price >= 0),
+                                           discount DECIMAL(10,2) DEFAULT 0 CHECK(discount >= 0),
+                                           observations TEXT,
+                                           FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_items_order ON order_items (order_id);
+
+CREATE TABLE IF NOT EXISTS order_item_condiments (
+                                                     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                                                     order_item_id UUID NOT NULL,
+                                                     name VARCHAR(255) NOT NULL,
+                                                     price DECIMAL(10,2) DEFAULT 0 CHECK(price >= 0),
+                                                     FOREIGN KEY (order_item_id) REFERENCES order_items(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+                                        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                                        order_id UUID NOT NULL,
+                                        payment_method VARCHAR(50) NOT NULL,
+                                        value DECIMAL(10,2) NOT NULL CHECK(value >= 0),
+                                        is_prepaid BOOLEAN DEFAULT false,
+                                        FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_payments_order ON payments (order_id);
+
+CREATE TABLE IF NOT EXISTS order_status_history (
+                                                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                                                    order_id UUID NOT NULL,
+                                                    status VARCHAR(50) NOT NULL CHECK(status IN ('RECEIVED', 'CONFIRMED', 'DISPATCHED', 'DELIVERED', 'CANCELED')),
+                                                    created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+                                                    origin VARCHAR(50),
+                                                    FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_history_order_date ON order_status_history (order_id, created_at);


### PR DESCRIPTION
Title: feat(database): Implementa migration inicial e configuração do JPA

### Descrição
Este PR estabelece a fundação do banco de dados da aplicação. Foi criado o script de migração inicial (V1) utilizando Flyway para versionamento do schema e configurado o arquivo `application.yml` para conexão com o PostgreSQL.

**Mudanças principais:**
* Criação do arquivo `V1__init_schema.sql` contendo as tabelas: `stores`, `orders`, `order_items`, `order_item_condiments`, `delivery_addresses`, `payments` e `order_status_history`.
* Definição de índices para otimização de consultas (`idx_orders_store`, `idx_orders_created_at`, etc.).
* Configuração do `application.yml` com variáveis de ambiente para `DB_URL`, `DB_USERNAME` e `DB_PASSWORD`.
* Ajustes de boas práticas no JPA: `ddl-auto` como `validate` (para segurança em produção) e `open-in-view` como `false` (performance).

### Issue Relacionada
Closes #2

### Tipo de Alteração
Por favor, marque o(s) tipo(s) de alteração que esta PR introduz.

- [x] `feat` (nova funcionalidade)
- [ ] `fix` (correção de bug)
- [ ] `refactor` (refatoração de código sem mudança de funcionalidade)
- [ ] `docs` (alteração apenas na documentação)
- [ ] `style` (formatação de código, sem impacto na lógica)
- [x] `chore` (mudanças em build ou dependências)

### Checklist de Revisão
- [x] O código segue as convenções de estilo do projeto.
- [x] Eu escrevi ou atualizei os testes necessários para esta mudança (N/A - Infraestrutura).
- [x] Os testes de unidade/integração estão passando.
- [x] A documentação foi atualizada (se necessário).
- [x] Minhas alterações não causam problemas de segurança.

### Como Testar
1. Certifique-se de que o container do Postgres está rodando: `docker-compose up -d`.
2. Execute a aplicação Spring Boot.
3. Observe os logs de inicialização: deve aparecer a execução do Flyway (`Successfully applied 1 migration`).
4. Conecte no banco de dados (via DBeaver ou CLI) e verifique se as tabelas foram criadas corretamente no schema `public`.
5. Verifique se a aplicação iniciou na porta 8080 sem erros de conexão JDBC.

### Observações Adicionais
Foi desativado o `Open Session In View` (`jpa.open-in-view: false`) para evitar problemas de performance com conexões de banco presas durante a renderização da resposta, forçando o fechamento da transação logo após a execução do Service.