### PR TITLE
feat: adicionar gerenciamento de status do pedido

### DIFF
--- a/Backend/src/main/java/com/cocobambu/delivery/controller/OrderController.java
+++ b/Backend/src/main/java/com/cocobambu/delivery/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.cocobambu.delivery.controller;
 
 import com.cocobambu.delivery.controller.api.OrderApi;
 import com.cocobambu.delivery.dto.request.CreateOrderRequest;
+import com.cocobambu.delivery.dto.request.UpdateOrderStatusRequest;
 import com.cocobambu.delivery.dto.response.OrderWrapperResponse;
 import com.cocobambu.delivery.service.OrderService;
 import com.cocobambu.delivery.util.UriLocationBuilderHelper;
@@ -56,5 +57,14 @@ public class OrderController implements OrderApi {
             @RequestParam(defaultValue = "10") int size
     ){
         return ResponseEntity.ok(service.getOrdersByStore(storeId, page, size));
+    }
+
+    @PatchMapping("/{id}/status")
+    @Override
+    public ResponseEntity<OrderWrapperResponse> updateOrderStatus(
+            @PathVariable UUID id,
+            @RequestBody @Valid UpdateOrderStatusRequest request
+    ){
+        return ResponseEntity.ok(service.updateOrderStatus(id, request));
     }
 }

--- a/Backend/src/main/java/com/cocobambu/delivery/controller/api/OrderApi.java
+++ b/Backend/src/main/java/com/cocobambu/delivery/controller/api/OrderApi.java
@@ -1,6 +1,7 @@
 package com.cocobambu.delivery.controller.api;
 
 import com.cocobambu.delivery.dto.request.CreateOrderRequest;
+import com.cocobambu.delivery.dto.request.UpdateOrderStatusRequest;
 import com.cocobambu.delivery.dto.response.OrderWrapperResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -69,5 +70,16 @@ public interface OrderApi {
             @Parameter(description = "UUID da loja") UUID storeId,
             @Parameter(description = "Página") int page,
             @Parameter(description = "Tamanho") int size
+    );
+
+    @Operation(summary = "Atualiza status do pedido", description = "Avança o status do pedido seguindo as regras da máquina de estados.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Status atualizado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Transição de status inválida", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Pedido não encontrado", content = @Content)
+    })
+    ResponseEntity<OrderWrapperResponse> updateOrderStatus(
+            @Parameter(description = "ID do pedido") UUID id,
+            @Parameter(description = "Novo status") UpdateOrderStatusRequest request
     );
 }

--- a/Backend/src/main/java/com/cocobambu/delivery/dto/request/UpdateOrderStatusRequest.java
+++ b/Backend/src/main/java/com/cocobambu/delivery/dto/request/UpdateOrderStatusRequest.java
@@ -1,0 +1,10 @@
+package com.cocobambu.delivery.dto.request;
+
+import com.cocobambu.delivery.enums.OrderStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateOrderStatusRequest(
+        @NotNull(message = "Status is required")
+        OrderStatus status
+) {
+}

--- a/Backend/src/main/java/com/cocobambu/delivery/enums/OrderStatus.java
+++ b/Backend/src/main/java/com/cocobambu/delivery/enums/OrderStatus.java
@@ -1,9 +1,40 @@
 package com.cocobambu.delivery.enums;
 
 public enum OrderStatus {
-    RECEIVED,
-    CONFIRMED,
-    DISPATCHED,
-    DELIVERED,
-    CANCELED
+    RECEIVED {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return newStatus == CONFIRMED || newStatus == CANCELED;
+        }
+    },
+
+    CONFIRMED {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return newStatus == DISPATCHED || newStatus == CANCELED;
+        }
+    },
+
+    DISPATCHED {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return newStatus == DELIVERED || newStatus == CANCELED;
+        }
+    },
+
+    DELIVERED {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return false;
+        }
+    },
+
+    CANCELED {
+        @Override
+        public boolean canTransitionTo(OrderStatus newStatus) {
+            return false;
+        }
+    };
+
+    public abstract boolean canTransitionTo(OrderStatus newStatus);
 }

--- a/Backend/src/main/java/com/cocobambu/delivery/mapper/OrderMapper.java
+++ b/Backend/src/main/java/com/cocobambu/delivery/mapper/OrderMapper.java
@@ -42,13 +42,13 @@ public abstract class OrderMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "totalPrice", ignore = true)
-    @Mapping(target = "lastStatus", constant = "RECEIVED")
-    @Mapping(target = "createdAt", expression = "java(java.time.OffsetDateTime.now())")
+    @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
-    @Mapping(target = "history", ignore = true)
     @Mapping(target = "store", ignore = true)
     @Mapping(target = "customerName", source = "customer.name")
     @Mapping(target = "customerPhone", source = "customer.temporaryPhone")
+    @Mapping(target = "lastStatus", ignore = true)
+    @Mapping(target = "history", ignore = true)
     public abstract Order toEntity(CreateOrderRequest request);
 
     @Mapping(target = "id", source = "orderId")

--- a/Backend/src/main/java/com/cocobambu/delivery/service/OrderService.java
+++ b/Backend/src/main/java/com/cocobambu/delivery/service/OrderService.java
@@ -1,11 +1,9 @@
 package com.cocobambu.delivery.service;
 
 import com.cocobambu.delivery.dto.request.CreateOrderRequest;
+import com.cocobambu.delivery.dto.request.UpdateOrderStatusRequest;
 import com.cocobambu.delivery.dto.response.OrderWrapperResponse;
-import com.cocobambu.delivery.service.usecase.CreateOrderUseCase;
-import com.cocobambu.delivery.service.usecase.GetAllOrdersUseCase;
-import com.cocobambu.delivery.service.usecase.GetOrderByIdUseCase;
-import com.cocobambu.delivery.service.usecase.GetOrdersByStoreUseCase;
+import com.cocobambu.delivery.service.usecase.*;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
@@ -18,12 +16,14 @@ public class OrderService {
     private final GetAllOrdersUseCase getAllOrdersUseCase;
     private final GetOrderByIdUseCase getOrderByIdUseCase;
     private final GetOrdersByStoreUseCase getOrdersByStoreUseCase;
+    private final UpdateOrderStatusUseCase updateOrderStatusUseCase;
 
-    public OrderService(CreateOrderUseCase createOrderUseCase, GetAllOrdersUseCase getAllOrdersUseCase, GetOrderByIdUseCase getOrderByIdUseCase, GetOrdersByStoreUseCase getOrdersByStoreUseCase) {
+    public OrderService(CreateOrderUseCase createOrderUseCase, GetAllOrdersUseCase getAllOrdersUseCase, GetOrderByIdUseCase getOrderByIdUseCase, GetOrdersByStoreUseCase getOrdersByStoreUseCase, UpdateOrderStatusUseCase updateOrderStatusUseCase) {
         this.createOrderUseCase = createOrderUseCase;
         this.getAllOrdersUseCase = getAllOrdersUseCase;
         this.getOrderByIdUseCase = getOrderByIdUseCase;
         this.getOrdersByStoreUseCase = getOrdersByStoreUseCase;
+        this.updateOrderStatusUseCase = updateOrderStatusUseCase;
     }
 
     public OrderWrapperResponse createOrder(CreateOrderRequest request){
@@ -40,5 +40,9 @@ public class OrderService {
 
     public Page<OrderWrapperResponse> getOrdersByStore(UUID storeId, int page, int size){
         return getOrdersByStoreUseCase.execute(storeId, page, size);
+    }
+
+    public OrderWrapperResponse updateOrderStatus(UUID orderId, UpdateOrderStatusRequest request){
+        return updateOrderStatusUseCase.execute(orderId, request);
     }
 }

--- a/Backend/src/main/java/com/cocobambu/delivery/service/usecase/CreateOrderUseCase.java
+++ b/Backend/src/main/java/com/cocobambu/delivery/service/usecase/CreateOrderUseCase.java
@@ -40,16 +40,8 @@ public class CreateOrderUseCase {
         Order order = mapper.toEntity(request);
         order.setId(UUID.randomUUID());
         order.setStore(store);
-        order.setLastStatus(OrderStatus.RECEIVED); // Status inicial sempre é RECEIVED
         order.setCreatedAt(now);
-
-        OrderStatusHistory history = new OrderStatusHistory();
-        history.setStatus(OrderStatus.RECEIVED);
-        history.setCreatedAt(now);
-        history.setOrder(order);
-        history.setOrigin(StatusOrigin.STORE);
-        order.getHistory().add(history); // adiciona na lista pra salvar em cascata
-
+        order.changeStatusTo(OrderStatus.RECEIVED, StatusOrigin.STORE, now); // ja adiciona no histórico automaticamente
         calculateOrderTotal(order);
         validateOrderTotals(order);
 

--- a/Backend/src/main/java/com/cocobambu/delivery/service/usecase/UpdateOrderStatusUseCase.java
+++ b/Backend/src/main/java/com/cocobambu/delivery/service/usecase/UpdateOrderStatusUseCase.java
@@ -1,0 +1,36 @@
+package com.cocobambu.delivery.service.usecase;
+
+import com.cocobambu.delivery.dto.request.UpdateOrderStatusRequest;
+import com.cocobambu.delivery.dto.response.OrderWrapperResponse;
+import com.cocobambu.delivery.entity.Order;
+import com.cocobambu.delivery.enums.StatusOrigin;
+import com.cocobambu.delivery.exception.ResourceNotFoundException;
+import com.cocobambu.delivery.mapper.OrderMapper;
+import com.cocobambu.delivery.repository.OrderRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Component
+public class UpdateOrderStatusUseCase {
+
+    private final OrderRepository orderRepository;
+    private final OrderMapper mapper;
+
+    public UpdateOrderStatusUseCase(OrderRepository orderRepository, OrderMapper mapper) {
+        this.orderRepository = orderRepository;
+        this.mapper = mapper;
+    }
+
+    @Transactional
+    public OrderWrapperResponse execute(UUID orderId, UpdateOrderStatusRequest request) {
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new ResourceNotFoundException("Order not found with id:" + orderId));
+
+        order.changeStatusTo(request.status(), StatusOrigin.STORE, OffsetDateTime.now());
+        return mapper.toResponse(orderRepository.save(order));
+    }
+}


### PR DESCRIPTION
### Título do Pull Request

feat(orders): Implementar fluxo de atualização de status com State Machine e histórico

---

### Descrição

Este PR implementa a lógica de **Atualização de Status do Pedido**, garantindo a integridade do ciclo de vida do pedido através de uma Máquina de Estados (State Machine) e registrando todo o histórico de alterações.

**Principais Implementações:**

1.  **Endpoint de Atualização:**
    * `PATCH /api/v1/orders/{id}/status`
    * Recebe o novo status e atualiza o pedido, mantendo a origem como `STORE` por padrão.

2.  **State Machine (Regras de Negócio):**
    * Lógica encapsulada no Enum `OrderStatus` (`canTransitionTo`).
    * Validação estrita de transições (ex: impede voltar de `CONFIRMED` para `RECEIVED`).
    * Lança `BusinessException` (400) com mensagem descritiva caso a transição seja inválida.

3.  **Refatoração da Entidade (Rich Domain Model):**
    * A lógica de mudança de estado foi movida para dentro da entidade `Order` no método `changeStatusTo`.
    * O método gerencia automaticamente a atualização do `last_status`, `updated_at` e a criação do novo registro em `order_status_history`.
    * Adição da anotação `@OrderBy("createdAt ASC")` na lista de histórico para garantir a ordem cronológica no retorno do JSON.

4.  **Correções Técnicas:**
    * Ajuste no `OrderMapper` para ignorar `lastStatus` e `history` na criação, delegando a inicialização para a Entidade e corrigindo o bug onde o primeiro status não era gravado.
    * Remoção do construtor "All Args" da entidade `Order` para evitar conflitos com o Hibernate/MapStruct.

---

### Issue Relacionada

Closes #10

---

### Tipo de Alteração

Por favor, marque o(s) tipo(s) de alteração que esta PR introduz.

- [x] `feat` (nova funcionalidade)
- [ ] `fix` (correção de bug - Mapper/Inicialização de lista)
- [x] `refactor` (refatoração para Domínio Rico na Entidade Order)
- [x] `docs` (alteração apenas na documentação - Swagger)
- [ ] `style` (formatação de código, sem impacto na lógica)
- [ ] `chore` (mudanças em build ou dependências)

---

### Checklist de Revisão

- [x] O código segue as convenções de estilo do projeto.
- [ ] Eu escrevi ou atualizei os testes necessários para esta mudança.
- [ ] Os testes de unidade/integração estão passando
- [x] A documentação foi atualizada (Swagger/OpenAPI).
- [x] Minhas alterações não causam problemas de segurança.

---

### Como Testar

1.  **Cenário de Sucesso:**
    * Crie um pedido (`POST /orders`). Status inicial: `RECEIVED`.
    * Atualize para `CONFIRMED`:
      ```json
      PATCH /api/v1/orders/{ID_DO_PEDIDO}/status
      { "status": "CONFIRMED" }
      ```
    * Verifique se retorna **200 OK** e se o array `statuses` contém os dois registros na ordem correta.

2.  **Cenário de Erro (Regra de Negócio):**
    * Tente voltar o status para `RECEIVED`.
    * Verifique se retorna **400 Bad Request** com a mensagem: *"Invalid status transition: CONFIRMED -> RECEIVED"*.

3.  **Cenário de Idempotência:**
    * Tente atualizar para `CONFIRMED` novamente (mesmo status atual).
    * O sistema deve aceitar (200 OK) mas **não** deve duplicar o registro no histórico.

---

### Observações Adicionais

A decisão de hardcodar `StatusOrigin.STORE` foi mantida conforme os requisitos atuais do sistema de gestão de pedidos. A validação de idempotência foi adicionada para evitar registros duplicados desnecessários no banco de dados.